### PR TITLE
Use rake to run rspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@ begin
 require "rake/extensiontask"
 require "rake_compiler_dock"
 require "shellwords"
+require "rspec/core/rake_task"
+
 
 spec = Bundler::GemHelper.gemspec
 
@@ -11,6 +13,9 @@ Rake::ExtensionTask.new("numo/narray", spec) do |ext|
   ext.cross_compile = true
   ext.cross_platform = cross_platforms
 end
+
+RSpec::Core::RakeTask.new("spec")
+Rake::Task[:spec].prerequisites << :compile
 
 pkg_dir = "pkg"
 windows_gem_paths = cross_platforms.collect do |platform|

--- a/spec/bit_spec.rb
+++ b/spec/bit_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), "../ext/numo/narray/narray")
+require_relative '../lib/numo/narray.so'
 #Numo::NArray.debug = true
 
 RSpec.configure do |config|

--- a/spec/narray_spec.rb
+++ b/spec/narray_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), "../ext/numo/narray/narray")
+require_relative "../lib/numo/narray.so"
 #Numo::NArray.debug = true
 
 RSpec.configure do |config|


### PR DESCRIPTION
This change  is the preparation for using travis-ci to run specs.

Applying this PR, you must use "rake compile" and "rake spec" to run specs.