### PR TITLE
Support ruby 2.5.0

### DIFF
--- a/lib/erbpp/line_number.rb
+++ b/lib/erbpp/line_number.rb
@@ -122,7 +122,7 @@ class ERB
         # skip
       elsif num==1
         f = @filename.dump
-        line.sub!(/_erbout = (''|String\.new);/, "_erbout = CountLnString.new(#{f});")
+        line.sub!(/_erbout = (\+?''|String\.new);/, "_erbout = CountLnString.new(#{f});")
       elsif /^; _erbout\.force_encoding/ =~ line
         line.sub!(/^;/,";_erbout.ln(#{num});")
       end


### PR DESCRIPTION
On Ruby 2.5.0, the code generated by ERB was changed.
It broke the code generation of numo-narray.